### PR TITLE
Debug missing telegram api credentials

### DIFF
--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -8,10 +8,14 @@ async function init(phoneNumber?: string) {
         throw new Error("Required input elements are missing.")
     }
 
-    const apiIdFromEnv = (process as any).env.TELEGRAM_API_ID
-    const apiHashFromEnv = (process as any).env.TELEGRAM_API_HASH
+    const apiIdFromEnv = (process as any).env.TELEGRAM_API_ID ?? (globalThis as any).TELEGRAM_API_ID
+    const apiHashFromEnv = (process as any).env.TELEGRAM_API_HASH ?? (globalThis as any).TELEGRAM_API_HASH
 
     if (!apiIdFromEnv || !apiHashFromEnv) {
+        console.error(
+            "Missing TELEGRAM_API_ID or TELEGRAM_API_HASH. These must be provided at build time for the static client (e.g., set in Vercel Production env) or exposed on globalThis.",
+            { TELEGRAM_API_ID: (globalThis as any)?.TELEGRAM_API_ID, TELEGRAM_API_HASH: (globalThis as any)?.TELEGRAM_API_HASH },
+        )
         alert("Server misconfiguration: missing TELEGRAM_API_ID or TELEGRAM_API_HASH.")
         throw new Error("Missing TELEGRAM_API_ID or TELEGRAM_API_HASH environment variables.")
     }


### PR DESCRIPTION
Make Telegram API environment variable lookup more robust and add a clearer error message.

This addresses the 'Server misconfiguration: missing TELEGRAM_API_ID or TELEGRAM_API_HASH' error, which occurs when Parcel (the bundler) fails to inline environment variables from Vercel at build time. The change adds a fallback to `globalThis` and provides a more informative console error to assist with debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-93025da6-651e-4c5d-848c-5bc042525dd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93025da6-651e-4c5d-848c-5bc042525dd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

