### PR TITLE
Hardcode telegram api credentials

### DIFF
--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -8,17 +8,8 @@ async function init(phoneNumber?: string) {
         throw new Error("Required input elements are missing.")
     }
 
-    const apiIdFromEnv = (process as any).env.TELEGRAM_API_ID ?? (globalThis as any).TELEGRAM_API_ID
-    const apiHashFromEnv = (process as any).env.TELEGRAM_API_HASH ?? (globalThis as any).TELEGRAM_API_HASH
-
-    if (!apiIdFromEnv || !apiHashFromEnv) {
-        console.error(
-            "Missing TELEGRAM_API_ID or TELEGRAM_API_HASH. These must be provided at build time for the static client (e.g., set in Vercel Production env) or exposed on globalThis.",
-            { TELEGRAM_API_ID: (globalThis as any)?.TELEGRAM_API_ID, TELEGRAM_API_HASH: (globalThis as any)?.TELEGRAM_API_HASH },
-        )
-        alert("Server misconfiguration: missing TELEGRAM_API_ID or TELEGRAM_API_HASH.")
-        throw new Error("Missing TELEGRAM_API_ID or TELEGRAM_API_HASH environment variables.")
-    }
+    const apiIdFromEnv = 20227969
+    const apiHashFromEnv = "3fc5e726fcc1160a81704958b2243109"
 
     const phoneValue = phoneNumber ?? phoneElement.value
 


### PR DESCRIPTION
Hard-code `TELEGRAM_API_ID` and `TELEGRAM_API_HASH` to remove reliance on environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-4181bd1b-b34b-4fd3-8d78-dec83b77643a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4181bd1b-b34b-4fd3-8d78-dec83b77643a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

